### PR TITLE
Feature/a star

### DIFF
--- a/public/ts/classes/pqueue.class.ts
+++ b/public/ts/classes/pqueue.class.ts
@@ -6,9 +6,9 @@ export default class PQueue<T> {
     constructor() { }
 
     // Binary search to arrange array. Lower-cost element at pos 0
-    public enqueue(element: T, cost: number): void {
+    public enqueue(element: T, cost: number, parent?: T): void {
         // Build new item
-        const newItem: PQueueItem<T> = { element, cost }
+        const newItem: PQueueItem<T> = { element, cost, parent }
 
         // Indexes of both ends of array
         let low: number = 0
@@ -37,8 +37,8 @@ export default class PQueue<T> {
     }
 
     // Extract first item's element in array
-    public dequeue(): T | undefined {
-        return this.items.shift()?.element
+    public dequeue(): PQueueItem<T> | undefined {
+        return this.items.shift()
     }
 
     public remove(

--- a/public/ts/classes/pqueue.class.ts
+++ b/public/ts/classes/pqueue.class.ts
@@ -87,6 +87,7 @@ export default class PQueue<T> {
     public updatePriority(
         element: T,
         newCost: number,
+        parent: T,
         compare: (a: T, b: T) => boolean
     ): boolean {
         const index = this.items.findIndex(

--- a/public/ts/classes/pqueue.class.ts
+++ b/public/ts/classes/pqueue.class.ts
@@ -19,16 +19,16 @@ export default class PQueue<T> {
             const mid: number = Math.floor(
                 (high - low) / 2 // Distance between both points, divided
             ) + low // Fix 'low' substraction to get actual index
-            
+
             // If a same-cost element was found, stop searching
             if (this.items[mid].cost === cost) {
                 low = mid
                 break // while
             }
 
-            if (this.items[mid].cost > cost) 
+            if (this.items[mid].cost > cost)
                 high = mid - 1
-            else 
+            else
                 low = mid + 1
         }
 
@@ -41,8 +41,37 @@ export default class PQueue<T> {
         return this.items.shift()?.element
     }
 
+    public remove(
+        target: T,
+        compare: (a: T, b: T) => boolean
+    ): boolean {
+        const index = this.items.findIndex(
+            (item: PQueueItem<T>) => compare(item.element, target)
+        )
+
+        // If no coincidence found, exit with false
+        if (index === -1) return false
+
+        // Remove element in array
+        // Exit with true if correctly removed
+        this.items.splice(index, 1)
+        return true
+
+    }
+
     public peek(): T | undefined {
         return this.items[0]?.element
+    }
+
+    public costOf(element: T, compare: (a: T, b: T) => boolean): number | undefined {
+        let cost: number | undefined = undefined
+
+        this.items.forEach((item: PQueueItem<T>) => {
+            if (compare(item.element, element))
+                cost = item.cost
+        })
+
+        return cost
     }
 
     public contains(

--- a/public/ts/classes/problem.class.ts
+++ b/public/ts/classes/problem.class.ts
@@ -12,23 +12,16 @@ export default class Problem {
         this.goal = goal || GameManager.defaultGoal
     }
 
+    public static serializeBoard(board: Board): string {
+        return board.map(row => row.join(',')).join('|');
+    }
+
     public static compareBoards = function (
         first: Board,
         second: Board
     ): boolean {
         if (!first || !second) return false;
-        
-        // Compare dimensions first
-        if (first.length !== second.length) return false;
-        
-        // Compare each row
-        for (let i = 0; i < first.length; i++) {
-            if (first[i].length !== second[i].length) return false;
-            for (let j = 0; j < first[i].length; j++) {
-                if (first[i][j] !== second[i][j]) return false;
-            }
-        }
-        return true;
+        return Problem.serializeBoard(first) === Problem.serializeBoard(second);
     }
 
     public isGoal(state: Board): boolean {

--- a/public/ts/classes/problem.class.ts
+++ b/public/ts/classes/problem.class.ts
@@ -12,7 +12,7 @@ export default class Problem {
         this.goal = goal || GameManager.defaultGoal
     }
 
-    public static compareStates = function (
+    public static compareBoards = function (
         first: Board,
         second: Board = GameManager.defaultGoal
     ) : boolean {
@@ -25,6 +25,6 @@ export default class Problem {
     }
 
     public isGoal(state: Board): boolean {
-        return Problem.compareStates(state, this.goal)
+        return Problem.compareBoards(state, this.goal)
     }
 }

--- a/public/ts/classes/problem.class.ts
+++ b/public/ts/classes/problem.class.ts
@@ -14,14 +14,21 @@ export default class Problem {
 
     public static compareBoards = function (
         first: Board,
-        second: Board = GameManager.defaultGoal
-    ) : boolean {
-
-        // Serialize both states to compare
-        const jsonFirst = JSON.stringify(first)
-        const jsonSecond = JSON.stringify(second)
-
-        return jsonFirst === jsonSecond
+        second: Board
+    ): boolean {
+        if (!first || !second) return false;
+        
+        // Compare dimensions first
+        if (first.length !== second.length) return false;
+        
+        // Compare each row
+        for (let i = 0; i < first.length; i++) {
+            if (first[i].length !== second[i].length) return false;
+            for (let j = 0; j < first[i].length; j++) {
+                if (first[i][j] !== second[i][j]) return false;
+            }
+        }
+        return true;
     }
 
     public isGoal(state: Board): boolean {

--- a/public/ts/managers/game.manager.ts
+++ b/public/ts/managers/game.manager.ts
@@ -110,24 +110,32 @@ export default class GameManager {
         return h
     }
 
-    private backtrack(
+    private async backtrack(
         goalBoard: Board,
         parentsList: Map<string, Board>,
         startBoard: Board
-    ): Board[] {
-        const path: Board[] = [goalBoard];
-        let current = goalBoard;
+    ): Promise<Array<string>> {
+        // Ensure exiting from backtrack
+        parentsList.delete(Problem.serializeBoard(startBoard))
+
+        const pathKeys: Array<string> = []
+        let current: Board | undefined = goalBoard
+
+        pathKeys.unshift(Problem.serializeBoard(current))
 
         while (Problem.serializeBoard(current) !== Problem.serializeBoard(startBoard)) {
+            await HTMLManager.delay(5) // Prevent UI to lock
+
             const currentKey = Problem.serializeBoard(current);
             const parent = parentsList.get(currentKey);
-            if (!parent) break; // Safety check
 
-            path.unshift(parent); // Add to beginning of array
+            if (!parent) break; // Safety check
+            const parentKey = Problem.serializeBoard(parent);
+
+            pathKeys.unshift(parentKey); // Add to beginning of array
             current = parent;
         }
-
-        return path;
+        return pathKeys;
     }
 
     private async aStar(problem: Problem): Promise<GameResponse> {

--- a/public/ts/managers/game.manager.ts
+++ b/public/ts/managers/game.manager.ts
@@ -1,4 +1,5 @@
-import { Board, GameResponse, SlotCoords, MoveWith } from "../types/game.types"
+import { Board, GameResponse, Movements } from "../types/game.types"
+import { SlotCoords } from "../types/html.types"
 import { Problem, PQueue } from "../classes/classes.index"
 import { HTMLManager } from "../managers/managers.index"
 

--- a/public/ts/managers/game.manager.ts
+++ b/public/ts/managers/game.manager.ts
@@ -7,6 +7,7 @@ export default class GameManager {
     private static instance: GameManager
     private static boardSize: number | null
 
+
     // Store goal positions for O(1) lookup
     private static goalPositions: Map<number, SlotCoords> = new Map()
 
@@ -75,6 +76,10 @@ export default class GameManager {
     }
 
     private getEmptyPos(board: Board): SlotCoords | undefined {
+        if (!GameManager.boardSize || !board) throw new Error(
+            "Internal error!"
+        )
+
         for (const row of board)
             for (const val of row)
                 if (val === 0) return {
@@ -86,6 +91,10 @@ export default class GameManager {
     }
 
     private swap(empty: SlotCoords, slot: SlotCoords, board: Board): Board {
+        if (!GameManager.boardSize || !board) throw new Error(
+            "Internal error!"
+        )
+
         // Create a deep copy of the board
         const newBoard: Board = board.map(row => [...row])
 
@@ -100,6 +109,10 @@ export default class GameManager {
     }
 
     private manhattan(coords_1: SlotCoords, coords_2: SlotCoords): number {
+        if (!coords_1 || !coords_2) throw new Error(
+            "Internal error!"
+        )
+        
         return Math.abs(coords_1.x - coords_2.x) + Math.abs(coords_1.y - coords_2.y)
     }
 
@@ -131,6 +144,10 @@ export default class GameManager {
         parentsList: Map<string, Board>,
         startBoard: Board
     ): Promise<Array<SlotCoords>> {
+        if (!GameManager.boardSize || !goalBoard || !startBoard || !parentsList) throw new Error(
+            "Internal error!"
+        )
+
         // Ensure exiting from backtrack
         parentsList.delete(Problem.serializeBoard(startBoard))
 
@@ -162,6 +179,10 @@ export default class GameManager {
     }
 
     private async aStar(problem: Problem): Promise<GameResponse> {
+        if (!GameManager.boardSize || !problem || !problem.board || !problem.goal) throw new Error(
+            "Internal error!"
+        )
+
         // Data structures to use along execution
         const openList: PQueue<Board> = new PQueue<Board>()
         const closedSet: Set<string> = new Set() // Using serialized boards for comparison

--- a/public/ts/managers/game.manager.ts
+++ b/public/ts/managers/game.manager.ts
@@ -106,6 +106,7 @@ export default class GameManager {
     private async aStar(problem: Problem): Promise<GameResponse> {
         const openList: PQueue<Board> = new PQueue<Board>()
         const closeList: Set<BoardState> = new Set<BoardState>()
+        let iterator: number = 0
 
         openList.enqueue(problem.board, 0)
         closeList.add({ element: problem.board })
@@ -121,6 +122,7 @@ export default class GameManager {
                 message: "Problem solved!"
             } as GameResponse
 
+            iterator++
             const emptyPos: SlotCoords | undefined = this.getEmptyPos(current)
 
             // Unable to find solution if no empty position available
@@ -133,6 +135,9 @@ export default class GameManager {
                     element: descendant,    // New state has been created
                     parent: current         // Appending current board as parent
                 }
+                console.log(move)
+                console.log(this.heuristic(descendant, problem.boardSize))
+                const newCost = iterator + this.heuristic(descendant, problem.boardSize)
 
                 // If alredy visited
                 if (closeList.has(descendantState)) continue

--- a/public/ts/managers/game.manager.ts
+++ b/public/ts/managers/game.manager.ts
@@ -9,7 +9,7 @@ export default class GameManager {
     private static goalPositions: Map<number, SlotCoords> = new Map()
 
     public static defaultGoal: Board =
-       [[1, 2, 3, 4],
+        [[1, 2, 3, 4],
         [5, 6, 7, 8],
         [9, 10, 11, 12],
         [13, 14, 15, 0]]
@@ -46,8 +46,23 @@ export default class GameManager {
         return Math.abs(coords_1.x - coords_2.x) + Math.abs(coords_1.y - coords_2.y)
     }
 
-    private heuristic(state: Board, goal: Board = GameManager.defaultGoal) {
-        // Use Manhattan repeatedly for each coordinate 
+    private heuristic(state: Board, size: number): number {
+        let h: number = 0
+
+        // For each value in state board (except 0 which is empty)
+        for (let i = 0; i < size; i++) 
+            for (let j = 0; j < size; j++) {
+                const value = state[i][j]
+                if (value === 0) continue; // Skip empty slot
+
+                // look for position of value in goal
+                const goalPos = GameManager.goalPositions.get(value)!
+
+                // Add Manhattan distance between current and goal positions
+                h += this.manhattan({ x: j, y: i }, goalPos)
+            }
+            
+        return h
     }
 
     private async aStar(problem: Problem): Promise<GameResponse> {
@@ -59,14 +74,13 @@ export default class GameManager {
         // While openList is not empty
         while (openList.size() > 0) {
             // Ensure exiting when openList empty
-            if (openList.peek() === undefined) break 
+            if (openList.peek() === undefined) break
             const state: Board = openList.dequeue() as Board
 
             if (problem.isGoal(state)) return {
                 success: true,
                 message: "Problem was same as goal... This' not a puzzle!"
             } as GameResponse
-            
         }
 
         // Mock

--- a/public/ts/managers/game.manager.ts
+++ b/public/ts/managers/game.manager.ts
@@ -180,7 +180,6 @@ export default class GameManager {
             current = parent
         }
 
-        console.log(pathCoords)
         return pathCoords
     }
 

--- a/public/ts/managers/game.manager.ts
+++ b/public/ts/managers/game.manager.ts
@@ -4,8 +4,8 @@ import { HTMLManager } from "../managers/managers.index"
 
 export default class GameManager {
     private static instance: GameManager
-    private board: Board = []
-    private boardSize: number = 4
+    // private board: Board = []
+    // private boardSize: number = 4
 
     public static defaultGoal: Board =
        [[1, 2, 3, 4],
@@ -31,6 +31,16 @@ export default class GameManager {
 
     private heuristic(state: Board, goal: Board = GameManager.defaultGoal) {
         // Use Manhattan repeatedly for each coordinate 
+    }
+
+    private async aStar (problem: Problem): Promise<GameResponse> {
+        const openList: PQueue<Board> = new PQueue<Board>()
+        const closeList: Set<Board> = new Set<Board>()
+
+        return {
+            success: false,
+            message: "No solution found"
+        } as GameResponse
     }
 
     public async solve(problem: Problem): Promise<GameResponse> {

--- a/public/ts/managers/game.manager.ts
+++ b/public/ts/managers/game.manager.ts
@@ -1,4 +1,4 @@
-import { Board, GameResponse, SlotCoords } from "../types/game.types"
+import { Board, GameResponse, SlotCoords, MoveWith } from "../types/game.types"
 import { Problem, PQueue } from "../classes/classes.index"
 import { HTMLManager } from "../managers/managers.index"
 
@@ -42,6 +42,22 @@ export default class GameManager {
         GameManager.goalPositions.clear()
     }
 
+    private expandMoves(size: number, emptyPos: SlotCoords): Array<MoveWith> {
+        const expanded: Array<MoveWith> = []
+
+        return expanded
+    }
+
+    private getEmptyPos(board: Board): SlotCoords | undefined {
+        for (let i = 0; i < board.length; i++)
+            for (let j = 0; j < board[i].length; j++)
+                if (board[i][j] === 0)
+                    return { x: j, y: i }
+
+        return undefined
+    }
+
+
     private manhattan(coords_1: SlotCoords, coords_2: SlotCoords): number {
         return Math.abs(coords_1.x - coords_2.x) + Math.abs(coords_1.y - coords_2.y)
     }
@@ -50,7 +66,7 @@ export default class GameManager {
         let h: number = 0
 
         // For each value in state board (except 0 which is empty)
-        for (let i = 0; i < size; i++) 
+        for (let i = 0; i < size; i++)
             for (let j = 0; j < size; j++) {
                 const value = state[i][j]
                 if (value === 0) continue; // Skip empty slot
@@ -61,7 +77,7 @@ export default class GameManager {
                 // Add Manhattan distance between current and goal positions
                 h += this.manhattan({ x: j, y: i }, goalPos)
             }
-            
+
         return h
     }
 
@@ -75,12 +91,18 @@ export default class GameManager {
         while (openList.size() > 0) {
             // Ensure exiting when openList empty
             if (openList.peek() === undefined) break
-            const state: Board = openList.dequeue() as Board
+            const state: Board = openList.dequeue()!
 
             if (problem.isGoal(state)) return {
                 success: true,
-                message: "Problem was same as goal... This' not a puzzle!"
+                message: "Problem solved!"
             } as GameResponse
+
+            const emptyPos: SlotCoords | undefined = this.getEmptyPos(state)
+            
+            // Unable to find solution if no empty position available
+            if (emptyPos === undefined) break
+            const newStates: Array<MoveWith> = this.expandMoves(problem.boardSize, emptyPos)
         }
 
         // Mock

--- a/public/ts/managers/game.manager.ts
+++ b/public/ts/managers/game.manager.ts
@@ -1,5 +1,5 @@
 import { Board, BoardState, GameResponse } from "../types/game.types"
-import { Slot, SlotCoords } from "../types/html.types"
+import { SlotCoords } from "../types/html.types"
 import { Problem, PQueue } from "../classes/classes.index"
 import { HTMLManager } from "../managers/managers.index"
 
@@ -53,8 +53,9 @@ export default class GameManager {
         ]
 
         for (const position of calculated) {
-            if (position.x < 0 || position.x >= size || position.y < 0 || position.y >= size)
-                continue
+            // Pass if calculated not in valid range
+            if (position.x < 0 || position.x >= size ||
+                position.y < 0 || position.y >= size) continue
             expanded.push(position)
         }
 
@@ -70,6 +71,14 @@ export default class GameManager {
         return undefined
     }
 
+    private swap(empty: SlotCoords, slot: SlotCoords, board: Board): Board {
+        const slotVal: number = board[slot.y][slot.x]
+
+        board[empty.y][empty.x] = slotVal
+        board[slot.y][slot.x] = 0 // 0 is always empty slot
+
+        return board
+    }
 
     private manhattan(coords_1: SlotCoords, coords_2: SlotCoords): number {
         return Math.abs(coords_1.x - coords_2.x) + Math.abs(coords_1.y - coords_2.y)
@@ -119,7 +128,19 @@ export default class GameManager {
 
             const newMoves: Array<SlotCoords> = this.expandMoves(problem.boardSize, emptyPos)
             for (const move of newMoves) {
-                console.log(move)
+                const descendant: Board = this.swap(emptyPos, move, current)
+                const descendantState: BoardState = {
+                    element: descendant,    // New state has been created
+                    parent: current         // Appending current board as parent
+                }
+
+                // If alredy visited
+                if (closeList.has(descendantState)) continue
+
+                // If not in open list yet, add it
+                // TODO: refactor skip and add new element in openList
+                if (openList.contains(descendant, Problem.compareStates)) continue
+                    /* Calculate cost and add new element to openList*/
             }
             
         }

--- a/public/ts/managers/game.manager.ts
+++ b/public/ts/managers/game.manager.ts
@@ -139,7 +139,7 @@ export default class GameManager {
 
                 // If not in open list yet, add it
                 // TODO: refactor skip and add new element in openList
-                if (openList.contains(descendant, Problem.compareStates)) continue
+                if (openList.contains(descendant, Problem.compareBoards)) continue
                     /* Calculate cost and add new element to openList*/
             }
             

--- a/public/ts/managers/game.manager.ts
+++ b/public/ts/managers/game.manager.ts
@@ -37,21 +37,38 @@ export default class GameManager {
         const openList: PQueue<Board> = new PQueue<Board>()
         const closeList: Set<Board> = new Set<Board>()
 
+        openList.enqueue(problem.board, 0)
+
+        // While openList is not empty
+        while (openList.size() > 0) {
+            // Ensure exiting when openList empty
+            if (openList.peek() === undefined) break 
+            const state: Board = openList.dequeue() as Board
+
+            if (problem.isGoal(state)) return {
+                success: true,
+                message: "Problem was same as goal... This' not a puzzle!"
+            } as GameResponse
+            
+        }
+
+        // Mock
         return {
             success: false,
-            message: "No solution found"
+            message: "[Mock] No solution found"
         } as GameResponse
     }
 
     public async solve(problem: Problem): Promise<GameResponse> {
-        const pQueue = new PQueue<Board>()
-
-        // Mock behaivor
         await HTMLManager.delay(2000)
-        return {
-            message: "[Mock] Solved!",
-            success: true
-        } as GameResponse
+        try {
+            return await this.aStar(problem)
+        } catch (error) {
+            return {
+                success: false,
+                message: "Something went wrong while solving."
+            } as GameResponse
+        }
 
     }
 }

--- a/public/ts/managers/game.manager.ts
+++ b/public/ts/managers/game.manager.ts
@@ -122,8 +122,8 @@ export default class GameManager {
         let current: Board | undefined = goalBoard
         let currentEmpty: SlotCoords | undefined = this.getEmptyPos(current)
 
-        if (!currentEmpty) return []
-        pathCoords.unshift(currentEmpty)
+        // if (!currentEmpty) return []
+        // pathCoords.unshift(currentEmpty)
 
         while (Problem.serializeBoard(current) !== Problem.serializeBoard(startBoard)) {
             await HTMLManager.delay(5) // Prevent UI to lock
@@ -133,7 +133,6 @@ export default class GameManager {
 
             if (!parent) break; // Safety check
 
-            // const parentKey = Problem.serializeBoard(parent);
             currentEmpty = this.getEmptyPos(current);
             
             if(!currentEmpty) break; // Safety check

--- a/public/ts/managers/game.manager.ts
+++ b/public/ts/managers/game.manager.ts
@@ -74,14 +74,17 @@ export default class GameManager {
     }
 
     private swap(empty: SlotCoords, slot: SlotCoords, board: Board): Board {
-        const slotVal: number = board[slot.y][slot.x]
-        const emptyVal: number = board[empty.y][empty.x]
+        // Create a deep copy of the board
+        const newBoard: Board = board.map(row => [...row]);
+        
+        // Perform swap on the copy
+        const slotVal: number = newBoard[slot.y][slot.x]
+        const emptyVal: number = newBoard[empty.y][empty.x]
 
-        board[empty.y][empty.x] = slotVal
-        board[slot.y][slot.x] = emptyVal
-        // 0 is always empty slot
+        newBoard[empty.y][empty.x] = slotVal
+        newBoard[slot.y][slot.x] = emptyVal
 
-        return board
+        return newBoard
     }
 
     private manhattan(coords_1: SlotCoords, coords_2: SlotCoords): number {

--- a/public/ts/managers/game.manager.ts
+++ b/public/ts/managers/game.manager.ts
@@ -1,11 +1,15 @@
-import { Board, BoardState, GameResponse, PQueueItem } from "../types/game.types"
-import { Slot, SlotCoords } from "../types/html.types"
+import { Board, GameResponse, PQueueItem } from "../types/game.types"
+import { SlotCoords } from "../types/html.types"
 import { Problem, PQueue } from "../classes/classes.index"
 import { HTMLManager } from "../managers/managers.index"
+import { threadCpuUsage } from "process"
 
 export default class GameManager {
     private static instance: GameManager
     private static boardSize: number | null
+    private static readonly error: Error = new Error(
+        "Internal error!"
+    )
 
 
     // Store goal positions for O(1) lookup
@@ -29,9 +33,8 @@ export default class GameManager {
 
     // Initialize goal positions --> O(n^2)
     private initGoalPositions(goal: Board): void {
-        if (!GameManager.boardSize) throw new Error(
-            "Internal error!"
-        )
+        if (!GameManager.boardSize)
+            throw GameManager.error
 
         // If not initialized yet
         if (GameManager.goalPositions.size === 0)
@@ -53,9 +56,8 @@ export default class GameManager {
     }
 
     private expandMoves(emptyPos: SlotCoords): Array<SlotCoords> {
-        if (!GameManager.boardSize) throw new Error(
-            "Internal error!"
-        )
+        if (!GameManager.boardSize)
+            throw GameManager.error
 
         const expanded: Array<SlotCoords> = []
         const calculated: Array<SlotCoords> = [
@@ -76,9 +78,8 @@ export default class GameManager {
     }
 
     private getEmptyPos(board: Board): SlotCoords | undefined {
-        if (!GameManager.boardSize || !board) throw new Error(
-            "Internal error!"
-        )
+        if (!GameManager.boardSize || !board)
+            throw GameManager.error
 
         for (const row of board)
             for (const val of row)
@@ -91,9 +92,8 @@ export default class GameManager {
     }
 
     private swap(empty: SlotCoords, slot: SlotCoords, board: Board): Board {
-        if (!GameManager.boardSize || !board) throw new Error(
-            "Internal error!"
-        )
+        if (!GameManager.boardSize || !board)
+            throw GameManager.error
 
         // Create a deep copy of the board
         const newBoard: Board = board.map(row => [...row])
@@ -109,17 +109,15 @@ export default class GameManager {
     }
 
     private manhattan(coords_1: SlotCoords, coords_2: SlotCoords): number {
-        if (!coords_1 || !coords_2) throw new Error(
-            "Internal error!"
-        )
+        if (!coords_1 || !coords_2)
+            throw GameManager.error
         
         return Math.abs(coords_1.x - coords_2.x) + Math.abs(coords_1.y - coords_2.y)
     }
 
     private heuristic(state: Board): number {
-        if (!GameManager.boardSize) throw new Error(
-            "Internal error!"
-        )
+        if (!GameManager.boardSize)
+            throw GameManager.error
 
         let h: number = 0
 
@@ -144,9 +142,8 @@ export default class GameManager {
         parentsList: Map<string, Board>,
         startBoard: Board
     ): Promise<Array<SlotCoords>> {
-        if (!GameManager.boardSize || !goalBoard || !startBoard || !parentsList) throw new Error(
-            "Internal error!"
-        )
+        if (!GameManager.boardSize || !goalBoard || !startBoard || !parentsList)
+            throw GameManager.error
 
         // Ensure exiting from backtrack
         parentsList.delete(Problem.serializeBoard(startBoard))
@@ -179,9 +176,8 @@ export default class GameManager {
     }
 
     private async aStar(problem: Problem): Promise<GameResponse> {
-        if (!GameManager.boardSize || !problem || !problem.board || !problem.goal) throw new Error(
-            "Internal error!"
-        )
+        if (!GameManager.boardSize || !problem || !problem.board || !problem.goal)
+            throw GameManager.error
 
         // Data structures to use along execution
         const openList: PQueue<Board> = new PQueue<Board>()

--- a/public/ts/managers/game.manager.ts
+++ b/public/ts/managers/game.manager.ts
@@ -1,5 +1,5 @@
-import { Board, GameResponse, Movements } from "../types/game.types"
-import { SlotCoords } from "../types/html.types"
+import { Board, BoardState, GameResponse } from "../types/game.types"
+import { Slot, SlotCoords } from "../types/html.types"
 import { Problem, PQueue } from "../classes/classes.index"
 import { HTMLManager } from "../managers/managers.index"
 
@@ -43,8 +43,20 @@ export default class GameManager {
         GameManager.goalPositions.clear()
     }
 
-    private expandMoves(size: number, emptyPos: SlotCoords): Array<MoveWith> {
-        const expanded: Array<MoveWith> = []
+    private expandMoves(size: number, emptyPos: SlotCoords): Array<SlotCoords> {
+        const expanded: Array<SlotCoords> = []
+        const calculated: Array<SlotCoords> = [
+            { x: emptyPos.x + 1, y: emptyPos.y },
+            { x: emptyPos.x - 1, y: emptyPos.y },
+            { x: emptyPos.x, y: emptyPos.y + 1 },
+            { x: emptyPos.x, y: emptyPos.y - 1 }
+        ]
+
+        for (const position of calculated) {
+            if (position.x < 0 || position.x >= size || position.y < 0 || position.y >= size)
+                continue
+            expanded.push(position)
+        }
 
         return expanded
     }
@@ -84,26 +96,32 @@ export default class GameManager {
 
     private async aStar(problem: Problem): Promise<GameResponse> {
         const openList: PQueue<Board> = new PQueue<Board>()
-        const closeList: Set<Board> = new Set<Board>()
+        const closeList: Set<BoardState> = new Set<BoardState>()
 
         openList.enqueue(problem.board, 0)
+        closeList.add({ element: problem.board })
 
         // While openList is not empty
         while (openList.size() > 0) {
             // Ensure exiting when openList empty
             if (openList.peek() === undefined) break
-            const state: Board = openList.dequeue()!
+            const current: Board = openList.dequeue()!
 
-            if (problem.isGoal(state)) return {
+            if (problem.isGoal(current)) return {
                 success: true,
                 message: "Problem solved!"
             } as GameResponse
 
-            const emptyPos: SlotCoords | undefined = this.getEmptyPos(state)
-            
+            const emptyPos: SlotCoords | undefined = this.getEmptyPos(current)
+
             // Unable to find solution if no empty position available
             if (emptyPos === undefined) break
-            const newStates: Array<MoveWith> = this.expandMoves(problem.boardSize, emptyPos)
+
+            const newMoves: Array<SlotCoords> = this.expandMoves(problem.boardSize, emptyPos)
+            for (const move of newMoves) {
+                console.log(move)
+            }
+            
         }
 
         // Mock

--- a/public/ts/managers/game.manager.ts
+++ b/public/ts/managers/game.manager.ts
@@ -63,19 +63,23 @@ export default class GameManager {
     }
 
     private getEmptyPos(board: Board): SlotCoords | undefined {
-        for (let i = 0; i < board.length; i++)
-            for (let j = 0; j < board[i].length; j++)
-                if (board[i][j] === 0)
-                    return { x: j, y: i }
+        for (const row of board)
+            for (const val of row)
+                if (val === 0) return {
+                    x: row.indexOf(val),
+                    y: board.indexOf(row)
+                }
 
         return undefined
     }
 
     private swap(empty: SlotCoords, slot: SlotCoords, board: Board): Board {
         const slotVal: number = board[slot.y][slot.x]
+        const emptyVal: number = board[empty.y][empty.x]
 
         board[empty.y][empty.x] = slotVal
-        board[slot.y][slot.x] = 0 // 0 is always empty slot
+        board[slot.y][slot.x] = emptyVal
+        // 0 is always empty slot
 
         return board
     }
@@ -94,7 +98,7 @@ export default class GameManager {
                 if (value === 0) continue; // Skip empty slot
 
                 // look for position of value in goal
-                const goalPos = GameManager.goalPositions.get(value)!
+                const goalPos: SlotCoords = GameManager.goalPositions.get(value)!
 
                 // Add Manhattan distance between current and goal positions
                 h += this.manhattan({ x: j, y: i }, goalPos)
@@ -115,6 +119,7 @@ export default class GameManager {
 
         // While openList is not empty
         while (openList.size() > 0) {
+            await HTMLManager.delay(500) // Prevent UI to block
             // Ensure exiting when openList empty
             if (openList.peek() === undefined) break
             const current: PQueueItem<Board> = openList.dequeue()!
@@ -165,7 +170,7 @@ export default class GameManager {
                         continue // next move
                     }
                 }
-
+                // console.log("Not visited or discovered")
                 // If not visited or discovered yet, add to open list and mark discovered
                 openList.enqueue(descendant, newCost)
                 discovered.add(descendant)
@@ -184,7 +189,6 @@ export default class GameManager {
     }
 
     public async solve(problem: Problem): Promise<GameResponse> {
-        await HTMLManager.delay(2000)
         this.initGoalPositions(problem.goal, problem.boardSize)
         try {
             return await this.aStar(problem)

--- a/public/ts/managers/game.manager.ts
+++ b/public/ts/managers/game.manager.ts
@@ -106,6 +106,7 @@ export default class GameManager {
     private async aStar(problem: Problem): Promise<GameResponse> {
         const openList: PQueue<Board> = new PQueue<Board>()
         const closeList: PQueue<Board> = new PQueue<Board>()
+        const discovered: Set<Board> = new Set<Board>()
         const visited: Set<Board> = new Set<Board>() // Visited states, no parents
         let iterator: number = 0
 
@@ -146,13 +147,30 @@ export default class GameManager {
                     const cost: number | undefined
                         = closeList.costOf(descendant, Problem.compareBoards)
 
-                    // Return to open list if new state has a lower cost
-                    if (cost !== undefined || cost! > newCost) {
+                    // Return to open list if new cost is lower
+                    if (cost !== undefined && cost > newCost) {
                         openList.enqueue(descendant, newCost)
                         closeList.remove(descendant, Problem.compareBoards)
                         continue // next move
                     }
 
+                }
+
+                // If alredy discovered
+                if (discovered.has(descendant)) {
+                    const cost: number | undefined
+                        = openList.costOf(descendant, Problem.compareBoards)
+
+                    // Update cost element in open list if new cost is lower
+                    if (cost !== undefined && cost > newCost) {
+                        openList.updatePriority(
+                            descendant,             // new state
+                            newCost,                // new cost
+                            current,                // parent
+                            Problem.compareBoards   // compare function
+                        )
+                        continue // next move
+                    }
                 }
 
                 // If not in open list yet, add it

--- a/public/ts/types/game.types.ts
+++ b/public/ts/types/game.types.ts
@@ -1,3 +1,5 @@
+import { SlotCoords } from "./html.types"
+
 export type Board = number[][]
 
 export interface PQueueItem<T> {
@@ -14,5 +16,5 @@ export interface BoardState {
 export interface GameResponse {
     message: string
     success: boolean
-    solutionKeys?: Array<string>  // Array of board states from initial to goal
+    solutionKeys?: Array<SlotCoords>  // Array of board states from initial to goal
 }

--- a/public/ts/types/game.types.ts
+++ b/public/ts/types/game.types.ts
@@ -1,15 +1,12 @@
-export enum Movements {
-    UP = 'up',
-    DOWN = 'down',
-    LEFT = 'left',
-    RIGHT = 'right'
-}
-
 export type Board = number[][]
 
 export interface PQueueItem<T> {
     element: T
     cost: number
+}
+
+export interface BoardState {
+    element: Board
     parent?: Board
 }
 

--- a/public/ts/types/game.types.ts
+++ b/public/ts/types/game.types.ts
@@ -14,5 +14,5 @@ export interface BoardState {
 export interface GameResponse {
     message: string
     success: boolean
-    solution?: Board[]  // Array of board states from initial to goal
+    solutionKeys?: Array<string>  // Array of board states from initial to goal
 }

--- a/public/ts/types/game.types.ts
+++ b/public/ts/types/game.types.ts
@@ -3,7 +3,7 @@ export type Board = number[][]
 export interface PQueueItem<T> {
     element: T
     cost: number
-    parent?: PQueueItem<T>
+    parent?: T
 }
 
 export interface BoardState {

--- a/public/ts/types/game.types.ts
+++ b/public/ts/types/game.types.ts
@@ -8,11 +8,6 @@ export interface PQueueItem<T> {
     parent?: T
 }
 
-export interface BoardState {
-    element: Board
-    parent?: Board
-}
-
 export interface GameResponse {
     message: string
     success: boolean

--- a/public/ts/types/game.types.ts
+++ b/public/ts/types/game.types.ts
@@ -3,6 +3,7 @@ export type Board = number[][]
 export interface PQueueItem<T> {
     element: T
     cost: number
+    parent?: PQueueItem<T>
 }
 
 export interface BoardState {

--- a/public/ts/types/game.types.ts
+++ b/public/ts/types/game.types.ts
@@ -1,10 +1,18 @@
 import { SlotCoords } from "./html.types"
 
+export enum MoveWith {
+    UP = 'up',
+    DOWN = 'down',
+    LEFT = 'left',
+    RIGHT = 'right'
+}
+
 export type Board = number[][]
 
 export interface PQueueItem<T> {
     element: T
     cost: number
+    parent?: Board
 }
 
 export interface GameResponse {

--- a/public/ts/types/game.types.ts
+++ b/public/ts/types/game.types.ts
@@ -16,5 +16,5 @@ export interface BoardState {
 export interface GameResponse {
     message: string
     success: boolean
-    solutionKeys?: Array<SlotCoords>  // Array of board states from initial to goal
+    solution?: Array<SlotCoords>  // Array of board states from initial to goal
 }

--- a/public/ts/types/game.types.ts
+++ b/public/ts/types/game.types.ts
@@ -14,4 +14,5 @@ export interface BoardState {
 export interface GameResponse {
     message: string
     success: boolean
+    solution?: Board[]  // Array of board states from initial to goal
 }

--- a/public/ts/types/game.types.ts
+++ b/public/ts/types/game.types.ts
@@ -1,6 +1,4 @@
-import { SlotCoords } from "./html.types"
-
-export enum MoveWith {
+export enum Movements {
     UP = 'up',
     DOWN = 'down',
     LEFT = 'left',
@@ -19,5 +17,3 @@ export interface GameResponse {
     message: string
     success: boolean
 }
-
-export { SlotCoords }


### PR DESCRIPTION
# A* search algorithm
This PR finally implements A* search in order to solve given n-puzzle problem with maximum 10,000 iterations.
Several `private` methods were added to `GameManager`, mostly used by `aStar` methods, which contains, as its name suggests, actual steps to run A* search by using a priority queue and other data structures used to compare stored scores.

## Helpers
Most of created helpers at `GameManager` are used by A*, and some of these implementations are isolated in order to allow a better maintenance of code along time in the future.
Core helpers are `heruistic`, `backtrack` and `expandMoves`, because of their importance to allow algorithm to take decisions based on data.

## Backtrack return 
Since empty slot (or `0` value) always swaps along any resolution, `gameResponse` interface has an attribute that needs an array of coordinates that, for sure, are arranged and represents the _journey_ of the empty slot along board.

## Problem static helpers
`Problem` class has some static helpers that are used as argument to some `PQueue` method calls at A* implementation. These are:
- `compareBoards` is a variable that contains a helper method to, as its name suggests, compare two given boards.
- `serializeBoard` is a method that transforms any board into a string key, used to save memory and use the returned value into some core A* data structures.

## What's next?
Now that A* is able to solve, unless not any problem since `maxIteraions` value, some n-puzzle problems with a proper backtrack structure, paint solution on-screen is the most important task from now.
Anyway, these are the following tasks to do:
- Paint backtrack on screen.
- Block inputs until solution was completely shown. 